### PR TITLE
[MINOR] Added Flow type name compatibility in Markdown generation

### DIFF
--- a/generate-markdown.js
+++ b/generate-markdown.js
@@ -12,6 +12,10 @@ handlebars.registerHelper('defaultProp', function(options) {
   return str.length > 0 ? '`' + str + '`' : "";
 });
 
+handlebars.registerHelper('ternary', function(test, yes, no) {
+  return test ? yes : no;
+});
+
 function _generateDevPortal(comp) {
   var templateSource = fs.readFileSync(__dirname + '/templates/dev-portal.hbs');
   var template = handlebars.compile(templateSource.toString(), {noEscape: true});

--- a/templates/component-partial.hbs
+++ b/templates/component-partial.hbs
@@ -1,12 +1,11 @@
-## {{component}}
-
+## {{displayName}}
 {{description}}
 
 {{#if hasProps}}
 ### Properties
 
-| Property | Type | Description | Default |
-| -------- | ---- | ----------- | ------- |
+| Property | Type | Description | Default | Required |
+| -------- | ---- | ----------- | ------- | -------- |
 {{#each props}}
 | *{{@key}}* | {{ternary flowType flowType.name type.name}} | {{description}} | {{#defaultProp}}{{defaultValue.value}}{{/defaultProp}}
 {{/each}}

--- a/templates/component-partial.hbs
+++ b/templates/component-partial.hbs
@@ -8,7 +8,7 @@
 | Property | Type | Description | Default |
 | -------- | ---- | ----------- | ------- |
 {{#each props}}
-| *{{@key}}* | {{type.name}} | {{description}} | {{#defaultProp}}{{defaultValue.value}}{{/defaultProp}}
+| *{{@key}}* | {{ternary flowType flowType.name type.name}} | {{description}} | {{#defaultProp}}{{defaultValue.value}}{{/defaultProp}}
 {{/each}}
 {{/if}}
 

--- a/templates/library-docs.hbs
+++ b/templates/library-docs.hbs
@@ -6,5 +6,4 @@
 
 {{> component this library=../library }}
 
-<hr/>
 {{/each}}


### PR DESCRIPTION
**Problem**
react-docgen allows the use of Flow as a Type checker, but does not store the type under the key "type", it does it under the key "flowType". 
The type name was hence not present if we use flow.

**Solution**
- Added a ternary helper to the markdown generator
- Used this helper to use flowType if defined in the prop, type if not defined.

**On the side**
- Fixed the component Name 
- removed a trailing tag
- Added the required field for props